### PR TITLE
Set limelight's blinkin to alert mode if limelight is switched off

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -309,7 +309,7 @@ FEEDER_SUBSYSTEM.setDefaultCommand(FeederIndex);
     }
     */
     if (OP_PAD.getButtonValue(ButtonCode.LIMELIGHT_LIGHT_OFF_OVERRIDE)) {
-      RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.HEARTBEAT);
+      RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.FIRE);
     }
     else {
       if (Robot.LIMELIGHT_SUBSYSTEM.isAligned()) {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -308,6 +308,9 @@ FEEDER_SUBSYSTEM.setDefaultCommand(FeederIndex);
       // RAVEN_BLINKIN_3.blinkGreen();
     }
     */
+    if (OP_PAD.getButtonValue(ButtonCode.LIMELIGHT_LIGHT_OFF_OVERRIDE)) {
+      RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.HEARTBEAT);
+    }
 
     if (Robot.LIMELIGHT_SUBSYSTEM.isAligned()) {
       if (Robot.SHOOTER_SUBSYSTEM.getReadyToShootTarmac()) {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -310,7 +310,8 @@ FEEDER_SUBSYSTEM.setDefaultCommand(FeederIndex);
     */
     if (OP_PAD.getButtonValue(ButtonCode.LIMELIGHT_LIGHT_OFF_OVERRIDE)) {
       RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.HEARTBEAT);
-    } else {
+    }
+    else {
       if (Robot.LIMELIGHT_SUBSYSTEM.isAligned()) {
         if (Robot.SHOOTER_SUBSYSTEM.getReadyToShootTarmac()) {
           RAVEN_BLINKIN_4.setBlink(BlinkinCalibrations.BLUE);
@@ -326,9 +327,6 @@ FEEDER_SUBSYSTEM.setDefaultCommand(FeederIndex);
         RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.RED);
       }
     }
-
-    
-
 
     if (Robot.CONVEYANCE_SUBSYSTEM.getConveyanceStagingBeamBreakHasBall() == false && Robot.FEEDER_SUBSYSTEM.getFeederHasBall() == false) {
       RAVEN_BLINKIN_3.setSolid(BlinkinCalibrations.RED);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -310,22 +310,24 @@ FEEDER_SUBSYSTEM.setDefaultCommand(FeederIndex);
     */
     if (OP_PAD.getButtonValue(ButtonCode.LIMELIGHT_LIGHT_OFF_OVERRIDE)) {
       RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.HEARTBEAT);
-    }
-
-    if (Robot.LIMELIGHT_SUBSYSTEM.isAligned()) {
-      if (Robot.SHOOTER_SUBSYSTEM.getReadyToShootTarmac()) {
-        RAVEN_BLINKIN_4.setBlink(BlinkinCalibrations.BLUE);
+    } else {
+      if (Robot.LIMELIGHT_SUBSYSTEM.isAligned()) {
+        if (Robot.SHOOTER_SUBSYSTEM.getReadyToShootTarmac()) {
+          RAVEN_BLINKIN_4.setBlink(BlinkinCalibrations.BLUE);
+        }
+        else {
+          RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.BLUE);
+        }
+      }
+      else if (Robot.LIMELIGHT_SUBSYSTEM.hasTargetSighted()) {
+        RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.YELLOW);
       }
       else {
-        RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.BLUE);
+        RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.RED);
       }
     }
-    else if (Robot.LIMELIGHT_SUBSYSTEM.hasTargetSighted()) {
-      RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.YELLOW);
-    }
-    else {
-      RAVEN_BLINKIN_4.setSolid(BlinkinCalibrations.RED);
-    }
+
+    
 
 
     if (Robot.CONVEYANCE_SUBSYSTEM.getConveyanceStagingBeamBreakHasBall() == false && Robot.FEEDER_SUBSYSTEM.getFeederHasBall() == false) {


### PR DESCRIPTION
RAVEN_BLINKIN_4 (the blinkin used for the limelight targeting) will be set to HEARBEAT mode in case the switch is set to off